### PR TITLE
Introduce optional plugin architecture 

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ link_directories(${base-types_LIBRARY_DIRS})
 add_library(${TARGET_NAME} SHARED ${SOURCES} ${HEADERS})
 target_link_libraries(${TARGET_NAME}
                       wbc-tools
+                      dl
                       ${base-types_LIBRARIES})
 
 set_target_properties(${TARGET_NAME} PROPERTIES

--- a/src/core/PluginLoader.cpp
+++ b/src/core/PluginLoader.cpp
@@ -1,0 +1,5 @@
+#include "PluginLoader.hpp"
+
+namespace wbc{
+PluginLoader::PluginMap* PluginLoader::plugin_map = 0;
+}

--- a/src/core/PluginLoader.hpp
+++ b/src/core/PluginLoader.hpp
@@ -1,0 +1,38 @@
+#ifndef PLUGIN_LOADER_HPP
+#define PLUGIN_LOADER_HPP
+
+#include <map>
+#include <dlfcn.h>
+
+namespace wbc {
+
+class PluginLoader{
+public:
+    typedef std::map<std::string, void*> PluginMap;
+
+    static void loadPlugin(const std::string& name){
+        void *handle = dlopen(std::string(name).c_str(), RTLD_NOW);
+        if(!handle)
+            throw std::runtime_error("Failed to load plugin " + name);
+        getPluginMap()->insert(std::make_pair(name, handle));
+    }
+
+    static void unloadPlugin(const std::string& name){
+        PluginMap::iterator it = getPluginMap()->find(name);
+        if(it == getPluginMap()->end())
+            throw std::runtime_error("Failed to unload plugin " + name + ". Is the plugin loaded?");
+        dlclose(it->second);
+    }
+
+    static PluginMap *getPluginMap(){
+        if(!plugin_map)
+            plugin_map = new PluginMap;
+        return plugin_map;
+    }
+private:
+    static PluginMap* plugin_map;
+};
+
+}
+
+#endif

--- a/src/core/RobotModelConfig.hpp
+++ b/src/core/RobotModelConfig.hpp
@@ -17,6 +17,7 @@ public:
         floating_base_state.pose.orientation.setIdentity();
         floating_base_state.twist.setZero();
         floating_base_state.acceleration.setZero();
+        type = "kdl";
     }
     RobotModelConfig(const std::string& file,
                      const std::vector<std::string> joint_names = {},
@@ -29,6 +30,7 @@ public:
                      const std::vector<std::string>& joint_blacklist = std::vector<std::string>()) :
         file(file),
         submechanism_file(submechanism_file),
+        type("kdl"),
         joint_names(joint_names),
         actuated_joint_names(actuated_joint_names),
         floating_base(floating_base),
@@ -43,6 +45,8 @@ public:
     std::string file;
     /** Only Hyrodyn models: Absolute path to submechanism file, which describes the kinematic structure including parallel mechanisms.*/
     std::string submechanism_file;
+    /** Model type. Must be the exact name of one of the registered robot model plugins. See src/robot_models for all available plugins. Default is kdl*/
+    std::string type;
     /** Optional: Order of joints used internally. If left empty, joint order will be alphabetical (from URDF parser). If not empty, this has to contain all non-fixed joints from URDF model. If floating_base is true,
       * additionally, the first 6 joint names have to be {floating_base_trans_x, floating_base_trans_y, floating_base_trans_z, floating_base_rot_x, floating_base_rot_y, floating_base_rot_z}.
       * The order here will be used in all computed quantities, like Jacobians, control output, etc.. Note: For Hyrodyn robot models, the joint order will be defined in the submechanism files, so this property will be ignored*/

--- a/src/core/RobotModelFactory.cpp
+++ b/src/core/RobotModelFactory.cpp
@@ -1,0 +1,5 @@
+#include "RobotModelFactory.hpp"
+
+namespace wbc{
+RobotModelFactory::RobotModelMap* RobotModelFactory::robot_model_map = 0;
+}

--- a/src/core/RobotModelFactory.hpp
+++ b/src/core/RobotModelFactory.hpp
@@ -1,0 +1,48 @@
+#ifndef ROBOT_MODEL_FACTORY_HPP
+#define ROBOT_MODEL_FACTORY_HPP
+
+#include "RobotModel.hpp"
+#include <map>
+
+namespace wbc {
+
+template<typename T> RobotModel* createT(){return new T;}
+
+struct RobotModelFactory{
+    typedef std::map<std::string, RobotModel*(*)()> RobotModelMap;
+
+    static RobotModel *createInstance(const std::string& name) {
+        RobotModelMap::iterator it = getRobotModelMap()->find(name);
+        if(it == getRobotModelMap()->end())
+            throw std::runtime_error("Failed to create instance of plugin " + name + ". Is the plugin registered?");
+        return it->second();
+    }
+
+    template<typename T>
+    static T* createInstance(const std::string& name){
+        RobotModel* tmp = createInstance(name);
+        T* ret = dynamic_cast<T*>(tmp);
+        return ret;
+    }
+
+    static RobotModelMap *getRobotModelMap(){
+        if(!robot_model_map)
+            robot_model_map = new RobotModelMap;
+        return robot_model_map;
+    }
+private:
+    static RobotModelMap *robot_model_map;
+};
+
+template<typename T>
+struct RobotModelRegistry : RobotModelFactory{
+    RobotModelRegistry(const std::string& name) {
+        RobotModelMap::iterator it = getRobotModelMap()->find(name);
+        if(it != getRobotModelMap()->end())
+            throw std::runtime_error("Failed to register plugin with name " + name + ". A plugin with the same name is already registered");
+        getRobotModelMap()->insert(std::make_pair(name, &createT<T>));
+    }
+};
+}
+
+#endif

--- a/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
+++ b/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
@@ -5,6 +5,8 @@
 
 namespace wbc{
 
+RobotModelRegistry<RobotModelHyrodyn> RobotModelHyrodyn::reg("hyrodyn");
+
 RobotModelHyrodyn::RobotModelHyrodyn(){
 }
 

--- a/src/robot_models/hyrodyn/RobotModelHyrodyn.hpp
+++ b/src/robot_models/hyrodyn/RobotModelHyrodyn.hpp
@@ -1,7 +1,7 @@
 #ifndef ROBOTMODELHYRODYN_HPP
 #define ROBOTMODELHYRODYN_HPP
 
-#include "../../core/RobotModel.hpp"
+#include "../../core/RobotModelFactory.hpp"
 #include "../../core/RobotModelConfig.hpp"
 
 #include <hyrodyn/robot_model_hyrodyn.hpp>
@@ -11,6 +11,9 @@
 namespace wbc{
 
 class RobotModelHyrodyn : public RobotModel{
+private:
+    static RobotModelRegistry<RobotModelHyrodyn> reg;
+
 protected:
     base::samples::RigidBodyStateSE3 rbs;
     std::string base_frame;
@@ -145,6 +148,7 @@ public:
     /** @brief Compute and return the inverse dynamics solution*/
     virtual void computeInverseDynamics(base::commands::Joints &solver_output);
 };
+
 }
 
 #endif

--- a/src/robot_models/kdl/RobotModelKDL.cpp
+++ b/src/robot_models/kdl/RobotModelKDL.cpp
@@ -12,6 +12,8 @@
 
 namespace wbc{
 
+RobotModelRegistry<RobotModelKDL> RobotModelKDL::reg("kdl");
+
 RobotModelKDL::RobotModelKDL(){
 }
 

--- a/src/robot_models/kdl/RobotModelKDL.hpp
+++ b/src/robot_models/kdl/RobotModelKDL.hpp
@@ -1,7 +1,7 @@
 #ifndef ROBOTMODELKDL_HPP
 #define ROBOTMODELKDL_HPP
 
-#include "../../core/RobotModel.hpp"
+#include "../../core/RobotModelFactory.hpp"
 #include "../../core/RobotModelConfig.hpp"
 
 #include <kdl/tree.hpp>
@@ -19,6 +19,9 @@ class KinematicChainKDL;
  *  and will be appropriately concatenated. This way you can describe e.g. geometric robot-object relationships or create multi-robot scenarios.
  */
 class RobotModelKDL : public RobotModel{
+private:
+
+    static RobotModelRegistry<RobotModelKDL> reg;
 
     std::vector<std::string> actuated_joint_names;
     std::string base_frame;

--- a/test/core/test_core.cpp
+++ b/test/core/test_core.cpp
@@ -1,5 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <core/ConstraintConfig.hpp>
+#include <core/PluginLoader.hpp>
+#include <core/RobotModelFactory.hpp>
 
 using namespace std;
 using namespace wbc;
@@ -70,3 +72,24 @@ BOOST_AUTO_TEST_CASE(constraint_config){
     jnt_config.weights = vector<double>(2,1);
     BOOST_CHECK_THROW(jnt_config.validate(), std::invalid_argument);
 }
+
+BOOST_AUTO_TEST_CASE(plugin_loader){
+    BOOST_CHECK_NO_THROW(PluginLoader::loadPlugin("libwbc-robot_models-kdl.so"));
+    PluginLoader::PluginMap *plugin_map = PluginLoader::getPluginMap();
+    BOOST_CHECK(plugin_map->size() == 1);
+    BOOST_CHECK(plugin_map->count("libwbc-robot_models-kdl.so") == 1);
+    BOOST_CHECK(plugin_map->at("libwbc-robot_models-kdl.so") != 0);
+    BOOST_CHECK_NO_THROW(PluginLoader::unloadPlugin("libwbc-robot_models-kdl.so"));
+}
+
+BOOST_AUTO_TEST_CASE(robot_model_factory){
+    BOOST_CHECK_NO_THROW(PluginLoader::loadPlugin("libwbc-robot_models-kdl.so"));
+    RobotModelFactory::RobotModelMap *robot_model_map = RobotModelFactory::getRobotModelMap();
+    BOOST_CHECK(robot_model_map->size() == 1);
+    BOOST_CHECK(robot_model_map->count("kdl") == 1);
+    BOOST_CHECK(robot_model_map->at("kdl") != 0);
+    RobotModel* model;
+    BOOST_CHECK_NO_THROW(model = RobotModelFactory::createInstance("kdl"));
+    BOOST_CHECK(model != 0);
+}
+


### PR DESCRIPTION
Load robot models at runtime and get rid of the Hyrodyn dependency
in the WBC orogen component. Plugins have to
register themselves by calling RobotModelRegistry() in their cpp file.