### PR TITLE
solvers-eiquadprog: Also tell the target about the include and link dirs

### DIFF
--- a/src/solvers/eiquadprog/CMakeLists.txt
+++ b/src/solvers/eiquadprog/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(${TARGET_NAME}
                       ${base-types_LIBRARIES}
                       eiquadprog)
 
+target_include_directories(${TARGET_NAME} PUBLIC ${base-types_INCLUDE_DIRS} ${eiquadprog_INCLUDE_DIRS})
+target_link_directories(${TARGET_NAME} PUBLIC ${base-types_LIBRARY_DIRS} ${eiquadprog_LIBRARY_DIRS})
+
 set_target_properties(${TARGET_NAME} PROPERTIES
        VERSION ${PROJECT_VERSION}
        SOVERSION ${API_VERSION})


### PR DESCRIPTION
This allows the cart_pos_ctrl_eiquadprog tutorial to build with
separate_prefixes=true

@dmronga , the other option is to have the pkg-config query or, at least include_directories in tutorials/kuka_iiwa/CMakeLists.txt