### PR TITLE
Make eiquadprog an IMPORTED_TARGET to make it available to other targets

### DIFF
--- a/src/solvers/eiquadprog/CMakeLists.txt
+++ b/src/solvers/eiquadprog/CMakeLists.txt
@@ -20,9 +20,6 @@ target_link_libraries(${TARGET_NAME}
                       ${base-types_LIBRARIES}
                       eiquadprog)
 
-target_include_directories(${TARGET_NAME} PUBLIC ${base-types_INCLUDE_DIRS} ${eiquadprog_INCLUDE_DIRS})
-target_link_directories(${TARGET_NAME} PUBLIC ${base-types_LIBRARY_DIRS} ${eiquadprog_LIBRARY_DIRS})
-
 set_target_properties(${TARGET_NAME} PROPERTIES
        VERSION ${PROJECT_VERSION}
        SOVERSION ${API_VERSION})

--- a/src/solvers/eiquadprog/CMakeLists.txt
+++ b/src/solvers/eiquadprog/CMakeLists.txt
@@ -1,7 +1,7 @@
 SET(TARGET_NAME wbc-solvers-eiquadprog)
 
 pkg_search_module(base-types REQUIRED base-types)
-pkg_search_module(eiquadprog REQUIRED eiquadprog)
+pkg_search_module(eiquadprog REQUIRED IMPORTED_TARGET eiquadprog)
 
 set(SOURCES EiquadprogSolver.cpp)
 set(HEADERS EiquadprogSolver.hpp)
@@ -18,7 +18,7 @@ add_library(${TARGET_NAME} SHARED ${SOURCES} ${HEADERS})
 target_link_libraries(${TARGET_NAME}
                       wbc-core
                       ${base-types_LIBRARIES}
-                      eiquadprog)
+                      PkgConfig::eiquadprog)
 
 set_target_properties(${TARGET_NAME} PROPERTIES
        VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
@dmronga this compiles on ubuntu 18.04 and 20.04. if you want to go back further, @planthaber 's solution probably has better backwards compatibility. Note that this relies on the eiquadprog .pc file being correct by actually including the eiquadprog library. There is a PR on the package_set for that.