### PR TITLE
Build with new master of urdfdom (after they switched to tinyxml2)

### DIFF
--- a/bin/joint_limits_from_urdf.cpp
+++ b/bin/joint_limits_from_urdf.cpp
@@ -2,6 +2,7 @@
 #include <tools/URDFTools.hpp>
 #include <base/JointLimits.hpp>
 #include <boost/program_options.hpp>
+#include <iostream>
 
 using namespace wbc;
 using namespace std;

--- a/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
+++ b/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
@@ -1,6 +1,7 @@
 #include "RobotModelHyrodyn.hpp"
 #include <base-logging/Logging.hpp>
 #include <urdf_parser/urdf_parser.h>
+#include <tinyxml2.h>
 #include <tools/URDFTools.hpp>
 
 namespace wbc{

--- a/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
+++ b/src/robot_models/hyrodyn/RobotModelHyrodyn.cpp
@@ -46,9 +46,9 @@ bool RobotModelHyrodyn::configure(const RobotModelConfig& cfg){
     // Read Joint Limits
     URDFTools::jointLimitsFromURDF(robot_urdf, joint_limits);
 
-    TiXmlDocument *doc = urdf::exportURDF(robot_urdf);
+    auto *doc = urdf::exportURDF(robot_urdf);
     std::string robot_urdf_file = "/tmp/floating_base_model.urdf";
-    doc->SaveFile(robot_urdf_file);
+    doc->SaveFile(robot_urdf_file.c_str());
     try{
         hyrodyn.load_robotmodel(robot_urdf_file, cfg.submechanism_file);
     }

--- a/src/robot_models/rbdl/RobotModelRBDL.cpp
+++ b/src/robot_models/rbdl/RobotModelRBDL.cpp
@@ -3,6 +3,7 @@
 #include <rbdl/rbdl_utils.h>
 #include <rbdl/addons/urdfreader/urdfreader.h>
 #include <base-logging/Logging.hpp>
+#include <tinyxml2.h>
 
 using namespace RigidBodyDynamics;
 

--- a/src/robot_models/rbdl/RobotModelRBDL.cpp
+++ b/src/robot_models/rbdl/RobotModelRBDL.cpp
@@ -49,9 +49,9 @@ bool RobotModelRBDL::configure(const RobotModelConfig& cfg){
         if(l.second->inertial)
             l.second->inertial->origin.rotation.setFromRPY(0,0,0);
     }
-    TiXmlDocument *doc = urdf::exportURDF(robot_urdf);
+    auto *doc = urdf::exportURDF(robot_urdf);
     std::string robot_urdf_file = "/tmp/robot.urdf";
-    doc->SaveFile(robot_urdf_file);
+    doc->SaveFile(robot_urdf_file.c_str());
 
     if(!Addons::URDFReadFromFile(robot_urdf_file.c_str(), rbdl_model.get(), cfg.floating_base)){
         LOG_ERROR_S << "Unable to parse urdf from file " << robot_urdf_file << std::endl;

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB SOURCES RELATIVE ${PROJECT_SOURCE_DIR}/src/types "*.cpp")
 pkg_search_module(base-types REQUIRED IMPORTED_TARGET base-types)
 pkg_search_module(base-logging REQUIRED IMPORTED_TARGET base-logging)
 pkg_search_module(urdfdom REQUIRED IMPORTED_TARGET urdfdom)
-pkg_search_module(tinyxml REQUIRED IMPORTED_TARGET tinyxml)
+pkg_search_module(tinyxml REQUIRED IMPORTED_TARGET tinyxml2)
 pkg_search_module(eigen3 REQUIRED IMPORTED_TARGET eigen3)
 
 list(APPEND PKGCONFIG_REQUIRES base-types)

--- a/src/tools/URDFTools.cpp
+++ b/src/tools/URDFTools.cpp
@@ -3,6 +3,7 @@
 #include <base-logging/Logging.hpp>
 #include <urdf_model/link.h>
 #include <stack>
+#include <iostream>
 
 namespace wbc {
 
@@ -123,8 +124,8 @@ std::vector<std::string> URDFTools::addFloatingBaseToURDF(urdf::ModelInterfaceSh
 
     std::vector<std::string> floating_base_names = {"floating_base_trans_x", "floating_base_trans_y", "floating_base_trans_z",
                                                     "floating_base_rot_x", "floating_base_rot_y", "floating_base_rot_z"};
-    TiXmlDocument *doc = urdf::exportURDF(robot_urdf);
-    TiXmlPrinter printer;
+    auto *doc = urdf::exportURDF(robot_urdf);
+    tinyxml2::XMLPrinter printer;
     doc->Accept(&printer);
     std::string robot_xml_string = printer.CStr();
     robot_xml_string.erase(robot_xml_string.find("</robot>"), std::string("</robot>").length());

--- a/src/tools/URDFTools.cpp
+++ b/src/tools/URDFTools.cpp
@@ -2,6 +2,7 @@
 #include <base/JointLimits.hpp>
 #include <base-logging/Logging.hpp>
 #include <urdf_model/link.h>
+#include <tinyxml2.h>
 #include <stack>
 #include <iostream>
 


### PR DESCRIPTION
FWIW: These are the required changes to build after urdfdom master switched to depend on tinyxml2 (instead of old tinyxml).

The rock package set provides the master version with the updated dependency (since this update: https://github.com/rock-core/rock-package_set/pull/261).

The latest urdfdom release (3.0.0) doesn't include this breaking change yet, though.

For further reading: https://discourse.ros.org/t/upcoming-api-break-in-urdfdom/34750