### PR TITLE
use tinyxml2 instead of tinyxml

### DIFF
--- a/bin/joint_limits_from_urdf.cpp
+++ b/bin/joint_limits_from_urdf.cpp
@@ -2,6 +2,7 @@
 #include <tools/URDFTools.hpp>
 #include <base/JointLimits.hpp>
 #include <boost/program_options.hpp>
+#include <iostream>
 
 using namespace wbc;
 using namespace std;

--- a/src/robot_models/rbdl/RobotModelRBDL.cpp
+++ b/src/robot_models/rbdl/RobotModelRBDL.cpp
@@ -3,6 +3,7 @@
 #include <rbdl/rbdl_utils.h>
 #include <rbdl/addons/urdfreader/urdfreader.h>
 #include <base-logging/Logging.hpp>
+#include <tinyxml2.h>
 
 using namespace RigidBodyDynamics;
 
@@ -49,9 +50,9 @@ bool RobotModelRBDL::configure(const RobotModelConfig& cfg){
         if(l.second->inertial)
             l.second->inertial->origin.rotation.setFromRPY(0,0,0);
     }
-    TiXmlDocument *doc = urdf::exportURDF(robot_urdf);
+    tinyxml2::XMLDocument *doc = urdf::exportURDF(robot_urdf);
     std::string robot_urdf_file = "/tmp/robot.urdf";
-    doc->SaveFile(robot_urdf_file);
+    doc->SaveFile(robot_urdf_file.c_str());
 
     if(!Addons::URDFReadFromFile(robot_urdf_file.c_str(), rbdl_model.get(), cfg.floating_base)){
         LOG_ERROR_S << "Unable to parse urdf from file " << robot_urdf_file << std::endl;

--- a/src/tools/URDFTools.cpp
+++ b/src/tools/URDFTools.cpp
@@ -3,6 +3,8 @@
 #include <base-logging/Logging.hpp>
 #include <urdf_model/link.h>
 #include <stack>
+#include <iostream>
+#include <tinyxml2.h>
 
 namespace wbc {
 
@@ -123,8 +125,8 @@ std::vector<std::string> URDFTools::addFloatingBaseToURDF(urdf::ModelInterfaceSh
 
     std::vector<std::string> floating_base_names = {"floating_base_trans_x", "floating_base_trans_y", "floating_base_trans_z",
                                                     "floating_base_rot_x", "floating_base_rot_y", "floating_base_rot_z"};
-    TiXmlDocument *doc = urdf::exportURDF(robot_urdf);
-    TiXmlPrinter printer;
+    tinyxml2::XMLDocument *doc = urdf::exportURDF(robot_urdf);
+    tinyxml2::XMLPrinter printer;
     doc->Accept(&printer);
     std::string robot_xml_string = printer.CStr();
     robot_xml_string.erase(robot_xml_string.find("</robot>"), std::string("</robot>").length());


### PR DESCRIPTION
due to changes in urdfdom that uses tinyxml with ros/urdfdom#186.

did not test, only made it compile