### PR TITLE
Fix HPIPM interface after update

### DIFF
--- a/src/solvers/hpipm/HPIPMSolver.cpp
+++ b/src/solvers/hpipm/HPIPMSolver.cpp
@@ -96,6 +96,7 @@ void HPIPMSolver::solve(const HierarchicalQP &hierarchical_qp, Eigen::VectorXd &
                        NULL,
                        NULL,
                        NULL,
+                       NULL,
                        qp_in);
 
     int ret = dense_qp_solve(qp_solver, qp_in, qp_out);

--- a/src/solvers/hpipm/HPIPMSolver.cpp
+++ b/src/solvers/hpipm/HPIPMSolver.cpp
@@ -44,8 +44,6 @@ void HPIPMSolver::solve(const HierarchicalQP &hierarchical_qp, Eigen::VectorXd &
         dims.nb = qp.bounded ? qp.nq : 0;
         dims.ng = qp.nin;
         dims.ns = 0;
-        dims.nsb = 0;
-        dims.nsg = 0;
 
         if(config)
             free(config);


### PR DESCRIPTION
The HPIPM interface changed recently. As we use the newest acados version, we get the HPIPM update as well.
Hence, this commits fix the now broken arc-opt HPIPM wrapper.