### PR TITLE
Fix Doxygen parameter names that no longer match the signatures

### DIFF
--- a/src/controllers/PlanarPotentialField.hpp
+++ b/src/controllers/PlanarPotentialField.hpp
@@ -28,7 +28,8 @@ public:
 
     /**
      * @brief Compute control update according to potential field equation
-     * @param gradient Computed gradient. Will be resized if gradient.size() != dimension.
+     * @param position Current position
+     * @return Computed gradient
      */
     virtual const Eigen::VectorXd& update(const Eigen::VectorXd& position);
 

--- a/src/core/RobotModel.hpp
+++ b/src/core/RobotModel.hpp
@@ -138,7 +138,7 @@ public:
     /** @brief Update kinematics/dynamics.
       * @param joint_positions Positions of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param joint_velocities Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
-      * @param joint_acceleration Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
+      * @param joint_accelerations Accelerations of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param fb_pose Pose of the floating base in world coordinates
       * @param fb_twist Twist of the floating base in "local-world-aligned" (hybrid) representation, i.e., with respect to a frame attached to the floating base (robot root),
       * but aligned to world coordinates

--- a/src/core/Task.hpp
+++ b/src/core/Task.hpp
@@ -21,8 +21,7 @@ public:
     Task();
 
     /** @brief Resizes all members
-      * @param nc Number of task variables
-      * @param nj Number of robot joints
+      * @param nv Number of task variables
       */
     Task(TaskConfig config, RobotModelPtr robot_model, uint nv, TaskType type);
     ~Task();

--- a/src/robot_models/hyrodyn/RobotModelHyrodyn.hpp
+++ b/src/robot_models/hyrodyn/RobotModelHyrodyn.hpp
@@ -32,7 +32,7 @@ public:
     /** @brief Update kinematics/dynamics.
       * @param joint_positions Positions of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param joint_velocities Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
-      * @param joint_acceleration Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
+      * @param joint_accelerations Accelerations of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param fb_pose Pose of the floating base in world coordinates
       * @param fb_twist Twist of the floating base in "local-world-aligned" (hybrid) representation, i.e., with respect to a frame attached to the floating base (robot root),
       * but aligned to world coordinates

--- a/src/robot_models/pinocchio/RobotModelPinocchio.hpp
+++ b/src/robot_models/pinocchio/RobotModelPinocchio.hpp
@@ -36,7 +36,7 @@ public:
     /** @brief Update kinematics/dynamics.
       * @param joint_positions Positions of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param joint_velocities Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
-      * @param joint_acceleration Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
+      * @param joint_accelerations Accelerations of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param fb_pose Pose of the floating base in world coordinates
       * @param fb_twist Twist of the floating base in "local-world-aligned" (hybrid) representation, i.e., with respect to a frame attached to the floating base (robot root),
       * but aligned to world coordinates
@@ -64,7 +64,6 @@ public:
 
     /** @brief Returns the Space Jacobian for the kinematic chain between root and the tip frame as full body Jacobian. Size of the Jacobian will be 6 x nJoints, where nJoints is the number of joints of the whole robot. The order of the
       * columns will be the same as the configured joint order of the robot. The columns that correspond to joints that are not part of the kinematic chain will have only zeros as entries.
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       * @return A 6xN matrix, where N is the number of robot joints
       */
@@ -72,7 +71,6 @@ public:
 
     /** @brief Returns the Body Jacobian for the kinematic chain between root and the tip frame as full body Jacobian. Size of the Jacobian will be 6 x nJoints, where nJoints is the number of joints of the whole robot. The order of the
       * columns will be the same as the configured joint order of the robot. The columns that correspond to joints that are not part of the kinematic chain will have only zeros as entries.
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       * @return A 6xN matrix, where N is the number of robot joints
       */
@@ -86,7 +84,6 @@ public:
     virtual const Eigen::MatrixXd &comJacobian();
 
     /** @brief Returns the spatial acceleration bias, i.e. the term Jdot*qdot
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       * @return A Nx1 vector, where N is the number of robot joints
       */

--- a/src/robot_models/rbdl/RobotModelRBDL.hpp
+++ b/src/robot_models/rbdl/RobotModelRBDL.hpp
@@ -36,7 +36,7 @@ public:
     /** @brief Update kinematics/dynamics.
       * @param joint_positions Positions of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param joint_velocities Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
-      * @param joint_acceleration Velocities of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
+      * @param joint_accelerations Accelerations of all independent joints. These have to be in the same order as used by the model (alphabetic). For getting the joint order, call jointNames().
       * @param fb_pose Pose of the floating base in world coordinates
       * @param fb_twist Twist of the floating base in "local-world-aligned" (hybrid) representation, i.e., with respect to a frame attached to the floating base (robot root),
       * but aligned to world coordinates
@@ -64,14 +64,12 @@ public:
 
     /** @brief Returns the Space Jacobian for the kinematic chain between root and the tip frame as full body Jacobian. Size of the Jacobian will be 6 x nJoints, where nJoints is the number of joints of the whole robot. The order of the
       * columns will be the same as the joint order of the robot. The columns that correspond to joints that are not part of the kinematic chain will have only zeros as entries.
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       */
     virtual const Eigen::MatrixXd &spaceJacobian(const std::string &frame_id);
 
     /** @brief Returns the Body Jacobian for the kinematic chain between root and the tip frame as full body Jacobian. Size of the Jacobian will be 6 x nJoints, where nJoints is the number of joints of the whole robot. The order of the
       * columns will be the same as the joint order of the robot. The columns that correspond to joints that are not part of the kinematic chain will have only zeros as entries.
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       */
     virtual const Eigen::MatrixXd &bodyJacobian(const std::string &frame_id);
@@ -84,7 +82,6 @@ public:
     virtual const Eigen::MatrixXd &comJacobian();
 
     /** @brief Returns the spatial acceleration bias, i.e. the term Jdot*qdot
-      * @param root_frame Root frame of the chain. Has to be a valid link in the robot model.
       * @param frame_id Tip frame of the chain. Has to be a valid link in the robot model.
       * @return A Nx1 vector, where N is the number of robot joints
       */

--- a/src/scenes/acceleration_reduced_tsid/AccelerationSceneReducedTSID.hpp
+++ b/src/scenes/acceleration_reduced_tsid/AccelerationSceneReducedTSID.hpp
@@ -80,7 +80,7 @@ public:
 
     /**
      * @brief Update the wbc scene and return the (updated) optimization problem
-     * @param ctrl_output Control solution that fulfill the given tasks as good as possible
+     * @return The (updated) optimization problem
      */
     virtual const HierarchicalQP& update();
 

--- a/src/scenes/acceleration_tsid/AccelerationSceneTSID.hpp
+++ b/src/scenes/acceleration_tsid/AccelerationSceneTSID.hpp
@@ -77,7 +77,7 @@ public:
 
     /**
      * @brief Update the wbc scene and return the (updated) optimization problem
-     * @param ctrl_output Control solution that fulfill the given tasks as good as possible
+     * @return The (updated) optimization problem
      */
     virtual const HierarchicalQP& update();
 

--- a/src/solvers/eiquadprog/EiquadprogSolver.hpp
+++ b/src/solvers/eiquadprog/EiquadprogSolver.hpp
@@ -37,7 +37,7 @@ public:
 
     /**
      * @brief solve Solve the given quadratic program
-     * @param constraints Description of the hierarchical quadratic program to solve. Each vector entry correspond to a stage in the hierarchy where
+     * @param hierarchical_qp Description of the hierarchical quadratic program to solve. Each vector entry correspond to a stage in the hierarchy where
      *                    the first entry has the highest priority. Currently only one priority level is implemented.
      * @param solver_output solution of the quadratic program
      */

--- a/src/solvers/proxqp/ProxQPSolver.hpp
+++ b/src/solvers/proxqp/ProxQPSolver.hpp
@@ -40,7 +40,7 @@ public:
 
     /**
      * @brief solve Solve the given quadratic program
-     * @param constraints Description of the hierarchical quadratic program to solve. Each vector entry correspond to a stage in the hierarchy where
+     * @param hierarchical_qp Description of the hierarchical quadratic program to solve. Each vector entry correspond to a stage in the hierarchy where
      *                    the first entry has the highest priority. Currently only one priority level is implemented.
      * @param solver_output solution of the quadratic program
      */

--- a/src/tasks/ContactForceTask.hpp
+++ b/src/tasks/ContactForceTask.hpp
@@ -13,7 +13,6 @@ public:
 
     /**
      * @brief Compute the cartesian task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the cartesian task matrix A
      */
     virtual void update() override;
 

--- a/src/tasks/ContactWrenchTask.hpp
+++ b/src/tasks/ContactWrenchTask.hpp
@@ -13,7 +13,6 @@ public:
 
     /**
      * @brief Compute the cartesian task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the cartesian task matrix A
      */
     virtual void update() override;
 

--- a/src/tasks/JointAccelerationTask.hpp
+++ b/src/tasks/JointAccelerationTask.hpp
@@ -17,7 +17,6 @@ public:
 
     /**
      * @brief Compute the joint task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the joint task matrix A
      */
     virtual void update() override;
 

--- a/src/tasks/JointVelocityTask.hpp
+++ b/src/tasks/JointVelocityTask.hpp
@@ -18,7 +18,6 @@ public:
 
     /**
      * @brief Compute the joint task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the joint task matrix A
      */
     virtual void update() override;
 

--- a/src/tasks/SpatialAccelerationTask.hpp
+++ b/src/tasks/SpatialAccelerationTask.hpp
@@ -24,7 +24,6 @@ public:
 
     /**
      * @brief Compute the cartesian task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the cartesian task matrix A
      */
     virtual void update() override;
 

--- a/src/tasks/SpatialVelocityTask.hpp
+++ b/src/tasks/SpatialVelocityTask.hpp
@@ -20,7 +20,6 @@ public:
 
     /**
      * @brief Compute the cartesian task matrix A
-     * @param robot_model Pointer to the robot model from which get the state and compute the cartesian task matrix A
      */
     virtual void update() override;
 


### PR DESCRIPTION
### Problem

23 `\param` tags across 16 headers name parameters that the function does not take. Doxygen emits a warning for each one, and the parameters that really are there stay undocumented.

They look like leftovers from earlier signatures. The pattern that shows this best is in the four robot models:

```cpp
* @param joint_acceleration Velocities of all independent joints. ...
virtual void update(const Eigen::VectorXd& joint_positions,
                    const Eigen::VectorXd& joint_velocities,
                    const Eigen::VectorXd& joint_accelerations,
```

Two things wrong in one line. The name lost its `s`, and the description still says *Velocities*, copied from the line above. So the acceleration argument reads as a duplicate of the velocity one.

The rest:

- **`root_frame`**, six times in `spaceJacobian`, `bodyJacobian` and `spatialAccelerationBias` in the Pinocchio and RBDL models. Each takes `frame_id` only. The prose above still says "between root and the tip frame", so the root used to be an argument and now comes from the model.
- **`robot_model`**, six times on `update()` in the task classes. That method takes no arguments at all; the model is a member.
- **`ctrl_output`**, twice on `update()` in the TSID scenes. Same thing, and here the text describes what the method returns, so it became `@return`.
- **`constraints`** in both solvers. The argument is `hierarchical_qp`.
- **`gradient`** in `PlanarPotentialField::update`. The argument is `position`; the gradient is the return value. The old text even said "Will be resized if gradient.size() != dimension", which no caller can act on any more.
- **`nc`** and **`nj`** in `Task`. `nc` was renamed to `nv`, and `nj` is no longer passed at all, `Task.cpp:15` reads `nj = robot_model->nj()`.

### Change

Names corrected where the parameter still exists, tags removed where it does not, and two turned into `@return` where the text was describing the return value. Comments only, no code touched.

### What I did not do

`Task`'s constructor takes `config`, `robot_model`, `nv` and `type`, and after this change only `nv` is documented. I left the other three alone rather than write descriptions you did not ask for. Say the word and I will add them in this PR.

### Checks

I could not build. The library needs Ubuntu with pinocchio, RBDL and hyrodyn, and I am on macOS. The change is comment-only, so the diff cannot affect compilation, but I would rather say that than imply a build I did not run.

What I did instead: a script that pulls every `\param` name out of each Doxygen block and compares it against the identifiers in the declaration that follows. It reported 23 before, and 0 after. Each of the 23 was read by hand before touching it.
