### PR TITLE
Fix OsqpSolver crash on cold start with osqp-eigen >= v0.9.0 (OSQP 1.0)

### DIFF
--- a/src/solvers/osqp/OsqpSolver.cpp
+++ b/src/solvers/osqp/OsqpSolver.cpp
@@ -54,6 +54,8 @@ void OsqpSolver::solve(const HierarchicalQP& hierarchical_qp, Eigen::VectorXd& s
         configured = false;
 
     if(!configured){
+        if(solver.isInitialized())
+            solver.clearSolver();
         resize(qp.nq, nc);
         configured = true;
         solver.initSolver();


### PR DESCRIPTION
## Problem

Building `wbc` with `-DSOLVER_OSQP=ON` against `osqp-eigen >= v0.9.0` (the first release compatible with OSQP `v1.0.0`) makes `OsqpSolver` abort at runtime with:

```
[OsqpEigen::Solver::initSolver] The solver has been already initialized. Please use clearSolver() method to deallocate memory.
```

`OsqpEigen::Solver::initSolver()` now rejects being called on an already-initialized solver. Older `osqp-eigen` (targeting OSQP 0.6.x) silently tolerated a repeated `initSolver()`, so the bug was latent until OSQP 1.0.

## Cause

In `OsqpSolver::solve()`, disabling warm-starting resets `configured` to `false` on every cycle, so the (re-)configure branch runs again and calls `initSolver()` on the solver that was already initialized on the previous cycle:

```cpp
if(!allow_warm_start)
    configured = false;

if(!configured){
    resize(qp.nq, nc);
    configured = true;
    solver.initSolver();   // called again on an already-initialized solver -> aborts
}
```

The abort therefore appears from the second cold-start cycle onward.

## Fix

Tear the solver down before re-initializing on the (re-)configure path:

```cpp
if(!configured){
    if(solver.isInitialized())
        solver.clearSolver();
    resize(qp.nq, nc);
    configured = true;
    solver.initSolver();
}
```

This is a no-op on the very first solve (`isInitialized() == false`) and never runs on the warm-start path (the `if(!configured)` branch is skipped), so behaviour is unchanged for OSQP 0.6.x builds while fixing the crash for OSQP 1.0. It also makes the "warm-start disabled" case an actual clean cold start instead of relying on the old wrapper ignoring the duplicate `initSolver()`.

## Environment where the crash was observed

- `osqp` 1.0.0, `osqp-eigen` v0.11.0
- `wbc` `master`, built with `-DSOLVER_OSQP=ON`

## Note on a separate, latent issue (not addressed here)

A few lines below, a constraint-count change is handled by re-`resize()`-ing but **not** re-initializing the solver:

```cpp
if(solver.data()->getData()->m != nc)
    resize(qp.nq, nc);
```

If the number of constraints changes between calls, the subsequent `update*` calls operate on a solver whose workspace still has the old dimensions. This is orthogonal to the crash fixed here and may warrant its own fix.
